### PR TITLE
Add default data store and admin close handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+.env
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+Thumbs.db
+dist/
+build/
+coverage/
+*.local

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,24 @@
+{
+  "secrets": {
+    "jwt": "cb361a730d4b5c85f86371ad652cfd51cb9b156ee3323cf7a1f757dc769a6a3a"
+  },
+  "users": [
+    {
+      "username": "admin",
+      "passwordHash": "$2a$10$BKwz.REeCv0as8j./hJfqOin7JjRaXxTUvB2R5eY4zRpfKvFx0PGu",
+      "role": "admin",
+      "firstName": "",
+      "lastName": "",
+      "profileImage": null,
+      "totpSecret": null,
+      "preferences": { "showNowPlaying": true, "appOrder": [] },
+      "createdAt": "2025-01-01T00:00:00.000Z"
+    }
+  ],
+  "invites": [],
+  "resetCodes": [],
+  "apps": [],
+  "features": { "showNowPlaying": true },
+  "sabnzbd": { "baseUrl": "", "apiKey": "" },
+  "integrations": { "plex": { "baseUrl": "", "token": "" } }
+}

--- a/index.html
+++ b/index.html
@@ -281,9 +281,12 @@
           <div class="space-y-2 max-w-xl">
             <input id="sabBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="Base URL (e.g., https://sab.zahariamedia.ca/)" />
             <input id="sabApiKey" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="API Key" />
-            <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+            <div class="flex gap-2">
+              <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+              <button id="testSab" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
+            </div>
           </div>
-        
+
           <h3 class="font-semibold mt-8 mb-2">Plex Settings</h3>
           <div class="space-y-2 max-w-xl">
             <input id="plexBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border"
@@ -294,7 +297,6 @@
               <button id="savePlex" class="px-4 py-2 btn-brand text-white rounded">Save Plex Settings</button>
               <button id="testPlex" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
             </div>
-            <pre id="plexTestResult" class="mono text-xs bg-black/40 border border-white/10 rounded p-2 whitespace-pre-wrap hidden"></pre>
           </div>
 
         </div>
@@ -611,10 +613,26 @@
 
             // Delete buttons (delegated)
             wrap.querySelectorAll('button[data-del]').forEach(btn=>{
-              btn.onclick = async ()=>{
+              btn.onclick = ()=>{
                 const id = btn.getAttribute('data-del');
-                if(!confirm('Delete this app?')) return;
-                try { await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' }); toast('App deleted'); await loadApps(); renderTiles(); } catch(e){ toast(e.error||'Delete failed','err'); }
+                const nameInput = wrap.querySelector(`input[data-k="name"][data-key="${id}"]`);
+                const appName = nameInput?.value?.trim() || '';
+                Modal.open({
+                  title: 'Delete App',
+                  bodyHTML: 'Are you sure you want to delete "<span id="delAppName"></span>"?',
+                  confirmText: 'Delete',
+                  onOpen: ()=>{ $('#delAppName').textContent = appName; },
+                  onConfirm: async ()=>{
+                    try {
+                      await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' });
+                      toast('App deleted');
+                      await loadApps();
+                      renderTiles();
+                    } catch(e){
+                      toast(e.error||'Delete failed','err');
+                    }
+                  }
+                });
               };
             });
           };
@@ -636,14 +654,48 @@
         }
 
         // SAB settings
-        try{ const sabCfg=await api('/api/sab'); $('#sabBaseUrl').value=sabCfg.sab.baseUrl||''; $('#sabApiKey').value=sabCfg.sab.apiKey||''; $('#saveSab').onclick=async ()=>{ await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) }); toast('SAB settings saved'); }; }catch{}
+        try{
+          const sabCfg=await api('/api/sab');
+          $('#sabBaseUrl').value=sabCfg.sab.baseUrl||'';
+          $('#sabApiKey').value=sabCfg.sab.apiKey||'';
+          const saveSabBtn=$('#saveSab');
+          if(saveSabBtn){
+            saveSabBtn.onclick=async ()=>{
+              await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) });
+              toast('SAB settings saved');
+              $('#testSab')?.click();
+            };
+          }
+          const testSabBtn=$('#testSab');
+          if(testSabBtn){
+            testSabBtn.onclick=async ()=>{
+              try{ const r=await api('/api/sab/test'); if(r.ok) toast('SAB connection successful'); else toast(`SAB test failed (status ${r.status})`,'err'); }
+              catch(e){ toast(e.error||'SAB test failed','err'); }
+            };
+          }
+        }catch{}
 
         // Plex settings
         try{
           const plexCfg = await api('/api/plex');
           if (plexCfg && plexCfg.plex){ const tokInput=$('#plexToken'); const urlInput=$('#plexBaseUrl'); if(tokInput) tokInput.value = plexCfg.plex.token || ''; if(urlInput) urlInput.value = plexCfg.plex.baseUrl || ''; }
-          const savePlexBtn=$('#savePlex'); if (savePlexBtn){ savePlexBtn.onclick = async ()=>{ const token=($('#plexToken')?.value||'').trim(); let baseUrl=($('#plexBaseUrl')?.value||'').trim(); await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) }); toast('Plex settings saved'); if($('#testPlex')) $('#testPlex').click(); }; }
-          const testBtn=$('#testPlex'); if (testBtn){ testBtn.onclick = async ()=>{ const wrap=$('#plexTestResult'); if(wrap){ wrap.classList.remove('hidden'); wrap.textContent='Testing…'; } try{ const result=await api('/api/plex/test'); if(wrap) wrap.textContent=JSON.stringify(result,null,2); }catch(e){ if(wrap) wrap.textContent='Error: '+(e?.message||e); } }; }
+          const savePlexBtn=$('#savePlex');
+          if (savePlexBtn){
+            savePlexBtn.onclick = async ()=>{
+              const token=($('#plexToken')?.value||'').trim();
+              let baseUrl=($('#plexBaseUrl')?.value||'').trim();
+              await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) });
+              toast('Plex settings saved');
+              $('#testPlex')?.click();
+            };
+          }
+          const testBtn=$('#testPlex');
+          if (testBtn){
+            testBtn.onclick = async ()=>{
+              try{ const result=await api('/api/plex/test'); if(result.ok) toast('Plex connection successful'); else toast(`Plex test failed (status ${result.status})`,'err'); }
+              catch(e){ toast(e.error||'Plex test failed','err'); }
+            };
+          }
         }catch{}
 
         await renderUsers();
@@ -795,6 +847,7 @@
       try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify(body) }); S.me=r.user; toast('Saved.'); const displayName=[S.me.firstName,S.me.lastName].filter(Boolean).join(' ')||S.me.username; $('#userName').textContent = displayName; const ua=$('#userAvatar'), ui=$('#userInitial'); if(S.me.profileImage){ ua.src=S.me.profileImage; ua.classList.remove('hidden'); ui.classList.add('hidden'); } else { ui.textContent = initialsFor(S.me); ui.classList.remove('hidden'); ua.classList.add('hidden'); } }
       catch(err){ toast(err.error||'Save failed','err'); }
     });
+    $('#btn-admin-close').onclick = ()=> show('#view-apps');
     $('#btn-settings-close').onclick = ()=> show('#view-apps');
 
     // SAB controls

--- a/public/index.html
+++ b/public/index.html
@@ -281,9 +281,12 @@
           <div class="space-y-2 max-w-xl">
             <input id="sabBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="Base URL (e.g., https://sab.zahariamedia.ca/)" />
             <input id="sabApiKey" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="API Key" />
-            <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+            <div class="flex gap-2">
+              <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+              <button id="testSab" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
+            </div>
           </div>
-        
+
           <h3 class="font-semibold mt-8 mb-2">Plex Settings</h3>
           <div class="space-y-2 max-w-xl">
             <input id="plexBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border"
@@ -294,7 +297,6 @@
               <button id="savePlex" class="px-4 py-2 btn-brand text-white rounded">Save Plex Settings</button>
               <button id="testPlex" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
             </div>
-            <pre id="plexTestResult" class="mono text-xs bg-black/40 border border-white/10 rounded p-2 whitespace-pre-wrap hidden"></pre>
           </div>
 
         </div>
@@ -611,10 +613,26 @@
 
             // Delete buttons (delegated)
             wrap.querySelectorAll('button[data-del]').forEach(btn=>{
-              btn.onclick = async ()=>{
+              btn.onclick = ()=>{
                 const id = btn.getAttribute('data-del');
-                if(!confirm('Delete this app?')) return;
-                try { await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' }); toast('App deleted'); await loadApps(); renderTiles(); } catch(e){ toast(e.error||'Delete failed','err'); }
+                const nameInput = wrap.querySelector(`input[data-k="name"][data-key="${id}"]`);
+                const appName = nameInput?.value?.trim() || '';
+                Modal.open({
+                  title: 'Delete App',
+                  bodyHTML: 'Are you sure you want to delete "<span id="delAppName"></span>"?',
+                  confirmText: 'Delete',
+                  onOpen: ()=>{ $('#delAppName').textContent = appName; },
+                  onConfirm: async ()=>{
+                    try {
+                      await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' });
+                      toast('App deleted');
+                      await loadApps();
+                      renderTiles();
+                    } catch(e){
+                      toast(e.error||'Delete failed','err');
+                    }
+                  }
+                });
               };
             });
           };
@@ -636,14 +654,48 @@
         }
 
         // SAB settings
-        try{ const sabCfg=await api('/api/sab'); $('#sabBaseUrl').value=sabCfg.sab.baseUrl||''; $('#sabApiKey').value=sabCfg.sab.apiKey||''; $('#saveSab').onclick=async ()=>{ await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) }); toast('SAB settings saved'); }; }catch{}
+        try{
+          const sabCfg=await api('/api/sab');
+          $('#sabBaseUrl').value=sabCfg.sab.baseUrl||'';
+          $('#sabApiKey').value=sabCfg.sab.apiKey||'';
+          const saveSabBtn=$('#saveSab');
+          if(saveSabBtn){
+            saveSabBtn.onclick=async ()=>{
+              await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) });
+              toast('SAB settings saved');
+              $('#testSab')?.click();
+            };
+          }
+          const testSabBtn=$('#testSab');
+          if(testSabBtn){
+            testSabBtn.onclick=async ()=>{
+              try{ const r=await api('/api/sab/test'); if(r.ok) toast('SAB connection successful'); else toast(`SAB test failed (status ${r.status})`,'err'); }
+              catch(e){ toast(e.error||'SAB test failed','err'); }
+            };
+          }
+        }catch{}
 
         // Plex settings
         try{
           const plexCfg = await api('/api/plex');
           if (plexCfg && plexCfg.plex){ const tokInput=$('#plexToken'); const urlInput=$('#plexBaseUrl'); if(tokInput) tokInput.value = plexCfg.plex.token || ''; if(urlInput) urlInput.value = plexCfg.plex.baseUrl || ''; }
-          const savePlexBtn=$('#savePlex'); if (savePlexBtn){ savePlexBtn.onclick = async ()=>{ const token=($('#plexToken')?.value||'').trim(); let baseUrl=($('#plexBaseUrl')?.value||'').trim(); await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) }); toast('Plex settings saved'); if($('#testPlex')) $('#testPlex').click(); }; }
-          const testBtn=$('#testPlex'); if (testBtn){ testBtn.onclick = async ()=>{ const wrap=$('#plexTestResult'); if(wrap){ wrap.classList.remove('hidden'); wrap.textContent='Testing…'; } try{ const result=await api('/api/plex/test'); if(wrap) wrap.textContent=JSON.stringify(result,null,2); }catch(e){ if(wrap) wrap.textContent='Error: '+(e?.message||e); } }; }
+          const savePlexBtn=$('#savePlex');
+          if (savePlexBtn){
+            savePlexBtn.onclick = async ()=>{
+              const token=($('#plexToken')?.value||'').trim();
+              let baseUrl=($('#plexBaseUrl')?.value||'').trim();
+              await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) });
+              toast('Plex settings saved');
+              $('#testPlex')?.click();
+            };
+          }
+          const testBtn=$('#testPlex');
+          if (testBtn){
+            testBtn.onclick = async ()=>{
+              try{ const result=await api('/api/plex/test'); if(result.ok) toast('Plex connection successful'); else toast(`Plex test failed (status ${result.status})`,'err'); }
+              catch(e){ toast(e.error||'Plex test failed','err'); }
+            };
+          }
         }catch{}
 
         await renderUsers();
@@ -795,6 +847,7 @@
       try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify(body) }); S.me=r.user; toast('Saved.'); const displayName=[S.me.firstName,S.me.lastName].filter(Boolean).join(' ')||S.me.username; $('#userName').textContent = displayName; const ua=$('#userAvatar'), ui=$('#userInitial'); if(S.me.profileImage){ ua.src=S.me.profileImage; ua.classList.remove('hidden'); ui.classList.add('hidden'); } else { ui.textContent = initialsFor(S.me); ui.classList.remove('hidden'); ua.classList.add('hidden'); } }
       catch(err){ toast(err.error||'Save failed','err'); }
     });
+    $('#btn-admin-close').onclick = ()=> show('#view-apps');
     $('#btn-settings-close').onclick = ()=> show('#view-apps');
 
     // SAB controls


### PR DESCRIPTION
## Summary
- Hook up the "Close Admin" button so it returns to the apps view
- Provide an initial `data.json` so user changes like app order persist
- Ignore node modules and other build artifacts with a `.gitignore`
- Add SABnzbd and Plex connection test buttons that report results via toast notifications

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b373e449b88328b832191ceee58a58