### PR TITLE
Persist data store and admin close handler with TOTP registration fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+.env
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.DS_Store
+Thumbs.db
+dist/
+build/
+coverage/
+*.local

--- a/app.mjs
+++ b/app.mjs
@@ -112,10 +112,10 @@ app.post('/api/register', async (req,res)=>{
   const nu = { username, passwordHash: await bcrypt.hash(String(password),10), role: inv.role||'user', firstName:'', lastName:'', profileImage:null, totpSecret: null, preferences:{ showNowPlaying:true, appOrder:[] }, createdAt: new Date().toISOString() };
   j.users.push(nu);
   inv.usedAt = new Date().toISOString(); inv.usedBy = username;
-  let otpauth = null;
-  if (enableTotp){ const secret = randomBase32(20); nu.totpSecret = secret; otpauth = makeOtpAuthURL(`${nu.username}@ZahariaMedia`, 'ZahariaMedia', secret); }
+  let otpauth = null, secret = null;
+  if (enableTotp){ secret = randomBase32(20); nu.totpSecret = secret; otpauth = makeOtpAuthURL(`${nu.username}@ZahariaMedia`, 'ZahariaMedia', secret); }
   save(j);
-  res.json({ ok:true, otpauth });
+  res.json({ ok:true, otpauth, secret });
 });
 
 // Password reset via admin-generated reset code
@@ -319,7 +319,7 @@ app.put('/api/me', authMiddleware, async (req,res)=>{
     save(j);
     const otpauth = makeOtpAuthURL(`${u.username}@ZahariaMedia`, 'ZahariaMedia', secret);
     const { passwordHash, ...userSafe } = u;
-    return res.json({ user: userSafe, otpauth });
+    return res.json({ user: userSafe, otpauth, secret });
   }
   if (mfaAction === 'verify'){
     if (!u.totpSecret) return res.status(400).json({ error:'No setup in progress' });

--- a/data/data.json
+++ b/data/data.json
@@ -1,0 +1,24 @@
+{
+  "secrets": {
+    "jwt": "cb361a730d4b5c85f86371ad652cfd51cb9b156ee3323cf7a1f757dc769a6a3a"
+  },
+  "users": [
+    {
+      "username": "admin",
+      "passwordHash": "$2a$10$BKwz.REeCv0as8j./hJfqOin7JjRaXxTUvB2R5eY4zRpfKvFx0PGu",
+      "role": "admin",
+      "firstName": "",
+      "lastName": "",
+      "profileImage": null,
+      "totpSecret": null,
+      "preferences": { "showNowPlaying": true, "appOrder": [] },
+      "createdAt": "2025-01-01T00:00:00.000Z"
+    }
+  ],
+  "invites": [],
+  "resetCodes": [],
+  "apps": [],
+  "features": { "showNowPlaying": true },
+  "sabnzbd": { "baseUrl": "", "apiKey": "" },
+  "integrations": { "plex": { "baseUrl": "", "token": "" } }
+}

--- a/index.html
+++ b/index.html
@@ -44,8 +44,6 @@
       box-shadow: 0 6px 30px rgba(0,0,0,.35);
     }
 
-    .qr canvas { width: 240px !important; height: 240px !important; image-rendering: pixelated; }
-    .qr-box { display: flex; gap: 16px; align-items: flex-start; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; word-break: break-all; }
     .tab{ border-bottom: 2px solid transparent; padding: .5rem .75rem; border-radius: .5rem .5rem 0 0; cursor:pointer }
     .tab.active{ border-color: rgba(255,255,255,.12); background: rgba(255,255,255,.05); }
@@ -178,21 +176,16 @@
           <button type="submit" class="w-full py-2 rounded btn-brand text-white font-semibold">Register</button>
         </form>
 
-        <div id="registerMfa" class="hidden mt-5 text-sm">
-          <div class="qr-box">
-            <div id="qr" class="qr bg-white p-2 rounded inline-block"></div>
-            <div class="space-y-2">
-              <div>
-                <div class="text-neutral-300">Setup link (otpauth)</div>
-                <div id="otpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
-                <button type="button" id="copyOtpauth" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
-              </div>
-              <div>
-                <div class="text-neutral-300">Secret</div>
-                <div id="otpsecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
-                <button type="button" id="copySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
-              </div>
-            </div>
+        <div id="registerMfa" class="hidden mt-5 text-sm space-y-4">
+          <div>
+            <div class="text-neutral-300">Setup link (otpauth)</div>
+            <div id="otpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
+            <button type="button" id="copyOtpauth" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
+          </div>
+          <div>
+            <div class="text-neutral-300">Secret</div>
+            <div id="otpsecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
+            <button type="button" id="copySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
           </div>
         </div>
 
@@ -281,9 +274,12 @@
           <div class="space-y-2 max-w-xl">
             <input id="sabBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="Base URL (e.g., https://sab.zahariamedia.ca/)" />
             <input id="sabApiKey" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="API Key" />
-            <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+            <div class="flex gap-2">
+              <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+              <button id="testSab" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
+            </div>
           </div>
-        
+
           <h3 class="font-semibold mt-8 mb-2">Plex Settings</h3>
           <div class="space-y-2 max-w-xl">
             <input id="plexBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border"
@@ -294,7 +290,6 @@
               <button id="savePlex" class="px-4 py-2 btn-brand text-white rounded">Save Plex Settings</button>
               <button id="testPlex" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
             </div>
-            <pre id="plexTestResult" class="mono text-xs bg-black/40 border border-white/10 rounded p-2 whitespace-pre-wrap hidden"></pre>
           </div>
 
         </div>
@@ -376,25 +371,22 @@
               </div>
             </div>
             <div id="mfaSetup" class="hidden mt-3">
-              <div class="qr-box">
-                <div id="mfaQr" class="qr bg-white p-2 rounded inline-block"></div>
-                <div class="space-y-2">
-                  <div>
-                    <div class="text-neutral-300">Setup link (otpauth)</div>
-                    <div id="mfaOtpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
-                    <button type="button" id="mfaCopyLink" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
-                  </div>
-                  <div>
-                    <div class="text-neutral-300">Secret</div>
-                    <div id="mfaSecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
-                    <button type="button" id="mfaCopySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
-                  </div>
-                  <div class="mt-2">
-                    <label class="block text-xs mb-1">Enter 6‑digit code from your app</label>
-                    <input id="mfaCode" class="w-48 px-2 py-2 rounded bg-white/5 border" placeholder="123456" inputmode="numeric" maxlength="6" />
-                  </div>
-                  <button type="button" id="mfaVerify" class="px-4 py-2 btn-brand text-white rounded">Verify & Save</button>
+              <div class="space-y-2">
+                <div>
+                  <div class="text-neutral-300">Setup link (otpauth)</div>
+                  <div id="mfaOtpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
+                  <button type="button" id="mfaCopyLink" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
                 </div>
+                <div>
+                  <div class="text-neutral-300">Secret</div>
+                  <div id="mfaSecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
+                  <button type="button" id="mfaCopySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
+                </div>
+                <div class="mt-2">
+                  <label class="block text-xs mb-1">Enter 6‑digit code from your app</label>
+                  <input id="mfaCode" class="w-48 px-2 py-2 rounded bg-white/5 border" placeholder="123456" inputmode="numeric" maxlength="6" />
+                </div>
+                <button type="button" id="mfaVerify" class="px-4 py-2 btn-brand text-white rounded">Verify & Save</button>
               </div>
             </div>
           </div>
@@ -424,7 +416,6 @@
   </div>
 
   <!-- QR lib -->
-  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
 
   <script>
     const S = { token: null, me: null, sabPage: 1, sabPages: 1, sabTimer: null, npTimer: null, apps: [] };
@@ -479,8 +470,6 @@
     // Tabs
     document.addEventListener('click', (e)=>{ const t=e.target.closest('.tab'); if(!t) return; document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active')); t.classList.add('active'); const k=t.dataset.tab; ['apps','users','invites'].forEach(name=> $('#tab-'+name)?.classList.toggle('hidden', name!==k)); });
 
-    function renderQRTo(container, text){ const box=$(container); if(!box) return; box.innerHTML=""; const c=document.createElement("canvas"); c.width=240; c.height=240; box.appendChild(c); try{ QRCode.toCanvas(c, text, { width:240, margin:1 }); }catch(e){ console.error(e); } }
-
     async function copyToClipboard(t){ try{ await navigator.clipboard.writeText(t); }catch{ const ta=document.createElement("textarea"); ta.value=t; document.body.appendChild(ta); ta.select(); document.execCommand("copy"); ta.remove(); } toast('Copied to clipboard'); }
 
     // Bootstrap token
@@ -500,7 +489,20 @@
     // Register
     document.getElementById('registerForm').addEventListener('submit', async (e)=>{
       e.preventDefault(); const fd=new FormData(e.target); const body={ inviteCode:fd.get('inviteCode'), username:fd.get('username'), password:fd.get('password'), enableTotp:!!fd.get('enableTotp') };
-      try{ const { otpauth } = await api('/api/register', { method:'POST', body: JSON.stringify(body) }); if(otpauth){ $('#registerMfa').classList.remove('hidden'); renderQRTo('#qr', otpauth); $('#otpauth').textContent=otpauth; try{ const u=new URL(otpauth); $('#otpsecret').textContent=new URLSearchParams(u.search).get('secret')||''; }catch{} $('#copyOtpauth').onclick=()=>copyToClipboard(otpauth); $('#copySecret').onclick=()=>{ try{ const u=new URL(otpauth); copyToClipboard(new URLSearchParams(u.search).get('secret')||''); }catch{} }; } toast('Account created! You can now sign in.'); show('#view-login'); }
+      try{
+        const { otpauth, secret } = await api('/api/register', { method:'POST', body: JSON.stringify(body) });
+        if(otpauth && secret){
+          $('#registerMfa').classList.remove('hidden');
+          $('#otpauth').textContent=otpauth;
+          $('#otpsecret').textContent=secret;
+          $('#copyOtpauth').onclick=()=>copyToClipboard(otpauth);
+          $('#copySecret').onclick=()=>copyToClipboard(secret);
+          toast('Account created! Copy the setup details into your authenticator then sign in.');
+        } else {
+          toast('Account created! You can now sign in.');
+          show('#view-login');
+        }
+      }
       catch(err){ toast(err.error||'Registration failed','err'); }
     });
     $('#btn-register-back').onclick = (e)=>{ e.preventDefault(); show('#view-login'); };
@@ -611,10 +613,26 @@
 
             // Delete buttons (delegated)
             wrap.querySelectorAll('button[data-del]').forEach(btn=>{
-              btn.onclick = async ()=>{
+              btn.onclick = ()=>{
                 const id = btn.getAttribute('data-del');
-                if(!confirm('Delete this app?')) return;
-                try { await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' }); toast('App deleted'); await loadApps(); renderTiles(); } catch(e){ toast(e.error||'Delete failed','err'); }
+                const nameInput = wrap.querySelector(`input[data-k="name"][data-key="${id}"]`);
+                const appName = nameInput?.value?.trim() || '';
+                Modal.open({
+                  title: 'Delete App',
+                  bodyHTML: 'Are you sure you want to delete "<span id="delAppName"></span>"?',
+                  confirmText: 'Delete',
+                  onOpen: ()=>{ $('#delAppName').textContent = appName; },
+                  onConfirm: async ()=>{
+                    try {
+                      await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' });
+                      toast('App deleted');
+                      await loadApps();
+                      renderTiles();
+                    } catch(e){
+                      toast(e.error||'Delete failed','err');
+                    }
+                  }
+                });
               };
             });
           };
@@ -636,14 +654,48 @@
         }
 
         // SAB settings
-        try{ const sabCfg=await api('/api/sab'); $('#sabBaseUrl').value=sabCfg.sab.baseUrl||''; $('#sabApiKey').value=sabCfg.sab.apiKey||''; $('#saveSab').onclick=async ()=>{ await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) }); toast('SAB settings saved'); }; }catch{}
+        try{
+          const sabCfg=await api('/api/sab');
+          $('#sabBaseUrl').value=sabCfg.sab.baseUrl||'';
+          $('#sabApiKey').value=sabCfg.sab.apiKey||'';
+          const saveSabBtn=$('#saveSab');
+          if(saveSabBtn){
+            saveSabBtn.onclick=async ()=>{
+              await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) });
+              toast('SAB settings saved');
+              $('#testSab')?.click();
+            };
+          }
+          const testSabBtn=$('#testSab');
+          if(testSabBtn){
+            testSabBtn.onclick=async ()=>{
+              try{ const r=await api('/api/sab/test'); if(r.ok) toast('SAB connection successful'); else toast(`SAB test failed (status ${r.status})`,'err'); }
+              catch(e){ toast(e.error||'SAB test failed','err'); }
+            };
+          }
+        }catch{}
 
         // Plex settings
         try{
           const plexCfg = await api('/api/plex');
           if (plexCfg && plexCfg.plex){ const tokInput=$('#plexToken'); const urlInput=$('#plexBaseUrl'); if(tokInput) tokInput.value = plexCfg.plex.token || ''; if(urlInput) urlInput.value = plexCfg.plex.baseUrl || ''; }
-          const savePlexBtn=$('#savePlex'); if (savePlexBtn){ savePlexBtn.onclick = async ()=>{ const token=($('#plexToken')?.value||'').trim(); let baseUrl=($('#plexBaseUrl')?.value||'').trim(); await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) }); toast('Plex settings saved'); if($('#testPlex')) $('#testPlex').click(); }; }
-          const testBtn=$('#testPlex'); if (testBtn){ testBtn.onclick = async ()=>{ const wrap=$('#plexTestResult'); if(wrap){ wrap.classList.remove('hidden'); wrap.textContent='Testing…'; } try{ const result=await api('/api/plex/test'); if(wrap) wrap.textContent=JSON.stringify(result,null,2); }catch(e){ if(wrap) wrap.textContent='Error: '+(e?.message||e); } }; }
+          const savePlexBtn=$('#savePlex');
+          if (savePlexBtn){
+            savePlexBtn.onclick = async ()=>{
+              const token=($('#plexToken')?.value||'').trim();
+              let baseUrl=($('#plexBaseUrl')?.value||'').trim();
+              await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) });
+              toast('Plex settings saved');
+              $('#testPlex')?.click();
+            };
+          }
+          const testBtn=$('#testPlex');
+          if (testBtn){
+            testBtn.onclick = async ()=>{
+              try{ const result=await api('/api/plex/test'); if(result.ok) toast('Plex connection successful'); else toast(`Plex test failed (status ${result.status})`,'err'); }
+              catch(e){ toast(e.error||'Plex test failed','err'); }
+            };
+          }
         }catch{}
 
         await renderUsers();
@@ -780,7 +832,7 @@
     function startNowPlayingPolling(){ clearInterval(S.npTimer); if(!shouldShowNowPlaying()){ $('#nowPlayingWrap').classList.add('hidden'); return; } fetchNowPlaying(); S.npTimer=setInterval(fetchNowPlaying, 5000); }
 
     function hasMfaEnabled(){ return !!(S.me && S.me.totpSecret); }
-    async function setupMfaUI(){ const box=$('#mfaBox'); if(!box) return; const enabled=hasMfaEnabled(); $('#mfaStatus').textContent = enabled ? 'Enabled' : 'Disabled'; $('#mfaStart').classList.toggle('hidden', enabled); $('#mfaDisable').classList.toggle('hidden', !enabled); $('#mfaSetup').classList.add('hidden'); $('#mfaStart').onclick = async ()=>{ try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'start' }) }); if(r.otpauth){ $('#mfaSetup').classList.remove('hidden'); $('#mfaOtpauth').textContent=r.otpauth; try{ const u=new URL(r.otpauth); $('#mfaSecret').textContent=new URLSearchParams(u.search).get('secret')||''; }catch{} renderQRTo('#mfaQr', r.otpauth); $('#mfaCopyLink').onclick=()=>copyToClipboard(r.otpauth); $('#mfaCopySecret').onclick=()=>{ try{ const u=new URL(r.otpauth); copyToClipboard(new URLSearchParams(u.search).get('secret')||''); }catch{} }; } }catch(e){ toast(e.error||'Failed to start setup','err'); } };
+    async function setupMfaUI(){ const box=$('#mfaBox'); if(!box) return; const enabled=hasMfaEnabled(); $('#mfaStatus').textContent = enabled ? 'Enabled' : 'Disabled'; $('#mfaStart').classList.toggle('hidden', enabled); $('#mfaDisable').classList.toggle('hidden', !enabled); $('#mfaSetup').classList.add('hidden'); $('#mfaStart').onclick = async ()=>{ try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'start' }) }); if(r.otpauth && r.secret){ $('#mfaSetup').classList.remove('hidden'); $('#mfaOtpauth').textContent=r.otpauth; $('#mfaSecret').textContent=r.secret; $('#mfaCopyLink').onclick=()=>copyToClipboard(r.otpauth); $('#mfaCopySecret').onclick=()=>copyToClipboard(r.secret); } }catch(e){ toast(e.error||'Failed to start setup','err'); } }; $('#mfaDisable').onclick = async ()=>{ if(!confirm('Disable authenticator app for this account?')) return; try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'disable' }) }); S.me=r.user; toast('MFA disabled'); setupMfaUI(); }catch(e){ toast(e.error||'Failed to disable','err'); } }; $('#mfaVerify').onclick = async ()=>{ const code=$('#mfaCode').value.trim(); if(!/^[0-9]{6}$/.test(code)){ toast('Enter the 6‑digit code from your app','err'); return; } try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'verify', code }) }); S.me=r.user; toast('MFA enabled and saved'); setupMfaUI(); }catch(e){ toast(e.error||'Verification failed','err'); } }; }
       $('#mfaDisable').onclick = async ()=>{ if(!confirm('Disable authenticator app for this account?')) return; try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'disable' }) }); S.me=r.user; toast('MFA disabled'); setupMfaUI(); }catch(e){ toast(e.error||'Failed to disable','err'); } };
       $('#mfaVerify').onclick = async ()=>{ const code=$('#mfaCode').value.trim(); if(!/^[0-9]{6}$/.test(code)){ toast('Enter the 6‑digit code from your app','err'); return; } try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'verify', code }) }); S.me=r.user; toast('MFA enabled and saved'); setupMfaUI(); }catch(e){ toast(e.error||'Verification failed','err'); } };
     }
@@ -795,6 +847,7 @@
       try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify(body) }); S.me=r.user; toast('Saved.'); const displayName=[S.me.firstName,S.me.lastName].filter(Boolean).join(' ')||S.me.username; $('#userName').textContent = displayName; const ua=$('#userAvatar'), ui=$('#userInitial'); if(S.me.profileImage){ ua.src=S.me.profileImage; ua.classList.remove('hidden'); ui.classList.add('hidden'); } else { ui.textContent = initialsFor(S.me); ui.classList.remove('hidden'); ua.classList.add('hidden'); } }
       catch(err){ toast(err.error||'Save failed','err'); }
     });
+    $('#btn-admin-close').onclick = ()=> show('#view-apps');
     $('#btn-settings-close').onclick = ()=> show('#view-apps');
 
     // SAB controls

--- a/public/index.html
+++ b/public/index.html
@@ -44,8 +44,6 @@
       box-shadow: 0 6px 30px rgba(0,0,0,.35);
     }
 
-    .qr canvas { width: 240px !important; height: 240px !important; image-rendering: pixelated; }
-    .qr-box { display: flex; gap: 16px; align-items: flex-start; }
     .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; word-break: break-all; }
     .tab{ border-bottom: 2px solid transparent; padding: .5rem .75rem; border-radius: .5rem .5rem 0 0; cursor:pointer }
     .tab.active{ border-color: rgba(255,255,255,.12); background: rgba(255,255,255,.05); }
@@ -178,21 +176,16 @@
           <button type="submit" class="w-full py-2 rounded btn-brand text-white font-semibold">Register</button>
         </form>
 
-        <div id="registerMfa" class="hidden mt-5 text-sm">
-          <div class="qr-box">
-            <div id="qr" class="qr bg-white p-2 rounded inline-block"></div>
-            <div class="space-y-2">
-              <div>
-                <div class="text-neutral-300">Setup link (otpauth)</div>
-                <div id="otpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
-                <button type="button" id="copyOtpauth" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
-              </div>
-              <div>
-                <div class="text-neutral-300">Secret</div>
-                <div id="otpsecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
-                <button type="button" id="copySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
-              </div>
-            </div>
+        <div id="registerMfa" class="hidden mt-5 text-sm space-y-4">
+          <div>
+            <div class="text-neutral-300">Setup link (otpauth)</div>
+            <div id="otpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
+            <button type="button" id="copyOtpauth" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
+          </div>
+          <div>
+            <div class="text-neutral-300">Secret</div>
+            <div id="otpsecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
+            <button type="button" id="copySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
           </div>
         </div>
 
@@ -281,9 +274,12 @@
           <div class="space-y-2 max-w-xl">
             <input id="sabBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="Base URL (e.g., https://sab.zahariamedia.ca/)" />
             <input id="sabApiKey" class="w-full px-3 py-2 rounded bg-white/5 border" placeholder="API Key" />
-            <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+            <div class="flex gap-2">
+              <button id="saveSab" class="px-4 py-2 btn-brand text-white rounded">Save SAB Settings</button>
+              <button id="testSab" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
+            </div>
           </div>
-        
+
           <h3 class="font-semibold mt-8 mb-2">Plex Settings</h3>
           <div class="space-y-2 max-w-xl">
             <input id="plexBaseUrl" class="w-full px-3 py-2 rounded bg-white/5 border"
@@ -294,7 +290,6 @@
               <button id="savePlex" class="px-4 py-2 btn-brand text-white rounded">Save Plex Settings</button>
               <button id="testPlex" class="px-4 py-2 bg-white/10 border border-white/10 rounded">Test connection</button>
             </div>
-            <pre id="plexTestResult" class="mono text-xs bg-black/40 border border-white/10 rounded p-2 whitespace-pre-wrap hidden"></pre>
           </div>
 
         </div>
@@ -376,25 +371,22 @@
               </div>
             </div>
             <div id="mfaSetup" class="hidden mt-3">
-              <div class="qr-box">
-                <div id="mfaQr" class="qr bg-white p-2 rounded inline-block"></div>
-                <div class="space-y-2">
-                  <div>
-                    <div class="text-neutral-300">Setup link (otpauth)</div>
-                    <div id="mfaOtpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
-                    <button type="button" id="mfaCopyLink" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
-                  </div>
-                  <div>
-                    <div class="text-neutral-300">Secret</div>
-                    <div id="mfaSecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
-                    <button type="button" id="mfaCopySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
-                  </div>
-                  <div class="mt-2">
-                    <label class="block text-xs mb-1">Enter 6‑digit code from your app</label>
-                    <input id="mfaCode" class="w-48 px-2 py-2 rounded bg-white/5 border" placeholder="123456" inputmode="numeric" maxlength="6" />
-                  </div>
-                  <button type="button" id="mfaVerify" class="px-4 py-2 btn-brand text-white rounded">Verify & Save</button>
+              <div class="space-y-2">
+                <div>
+                  <div class="text-neutral-300">Setup link (otpauth)</div>
+                  <div id="mfaOtpauth" class="mono bg-white/5 border border-white/10 rounded p-2 max-w-[520px]"></div>
+                  <button type="button" id="mfaCopyLink" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy setup link</button>
                 </div>
+                <div>
+                  <div class="text-neutral-300">Secret</div>
+                  <div id="mfaSecret" class="mono bg-white/5 border border-white/10 rounded p-2 inline-block"></div>
+                  <button type="button" id="mfaCopySecret" class="mt-2 px-3 py-1.5 rounded bg-white/10 hover:bg-white/20 text-xs">Copy secret</button>
+                </div>
+                <div class="mt-2">
+                  <label class="block text-xs mb-1">Enter 6‑digit code from your app</label>
+                  <input id="mfaCode" class="w-48 px-2 py-2 rounded bg-white/5 border" placeholder="123456" inputmode="numeric" maxlength="6" />
+                </div>
+                <button type="button" id="mfaVerify" class="px-4 py-2 btn-brand text-white rounded">Verify & Save</button>
               </div>
             </div>
           </div>
@@ -424,7 +416,6 @@
   </div>
 
   <!-- QR lib -->
-  <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.3/build/qrcode.min.js"></script>
 
   <script>
     const S = { token: null, me: null, sabPage: 1, sabPages: 1, sabTimer: null, npTimer: null, apps: [] };
@@ -479,8 +470,6 @@
     // Tabs
     document.addEventListener('click', (e)=>{ const t=e.target.closest('.tab'); if(!t) return; document.querySelectorAll('.tab').forEach(x=>x.classList.remove('active')); t.classList.add('active'); const k=t.dataset.tab; ['apps','users','invites'].forEach(name=> $('#tab-'+name)?.classList.toggle('hidden', name!==k)); });
 
-    function renderQRTo(container, text){ const box=$(container); if(!box) return; box.innerHTML=""; const c=document.createElement("canvas"); c.width=240; c.height=240; box.appendChild(c); try{ QRCode.toCanvas(c, text, { width:240, margin:1 }); }catch(e){ console.error(e); } }
-
     async function copyToClipboard(t){ try{ await navigator.clipboard.writeText(t); }catch{ const ta=document.createElement("textarea"); ta.value=t; document.body.appendChild(ta); ta.select(); document.execCommand("copy"); ta.remove(); } toast('Copied to clipboard'); }
 
     // Bootstrap token
@@ -500,7 +489,20 @@
     // Register
     document.getElementById('registerForm').addEventListener('submit', async (e)=>{
       e.preventDefault(); const fd=new FormData(e.target); const body={ inviteCode:fd.get('inviteCode'), username:fd.get('username'), password:fd.get('password'), enableTotp:!!fd.get('enableTotp') };
-      try{ const { otpauth } = await api('/api/register', { method:'POST', body: JSON.stringify(body) }); if(otpauth){ $('#registerMfa').classList.remove('hidden'); renderQRTo('#qr', otpauth); $('#otpauth').textContent=otpauth; try{ const u=new URL(otpauth); $('#otpsecret').textContent=new URLSearchParams(u.search).get('secret')||''; }catch{} $('#copyOtpauth').onclick=()=>copyToClipboard(otpauth); $('#copySecret').onclick=()=>{ try{ const u=new URL(otpauth); copyToClipboard(new URLSearchParams(u.search).get('secret')||''); }catch{} }; } toast('Account created! You can now sign in.'); show('#view-login'); }
+      try{
+        const { otpauth, secret } = await api('/api/register', { method:'POST', body: JSON.stringify(body) });
+        if(otpauth && secret){
+          $('#registerMfa').classList.remove('hidden');
+          $('#otpauth').textContent=otpauth;
+          $('#otpsecret').textContent=secret;
+          $('#copyOtpauth').onclick=()=>copyToClipboard(otpauth);
+          $('#copySecret').onclick=()=>copyToClipboard(secret);
+          toast('Account created! Copy the setup details into your authenticator then sign in.');
+        } else {
+          toast('Account created! You can now sign in.');
+          show('#view-login');
+        }
+      }
       catch(err){ toast(err.error||'Registration failed','err'); }
     });
     $('#btn-register-back').onclick = (e)=>{ e.preventDefault(); show('#view-login'); };
@@ -611,10 +613,26 @@
 
             // Delete buttons (delegated)
             wrap.querySelectorAll('button[data-del]').forEach(btn=>{
-              btn.onclick = async ()=>{
+              btn.onclick = ()=>{
                 const id = btn.getAttribute('data-del');
-                if(!confirm('Delete this app?')) return;
-                try { await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' }); toast('App deleted'); await loadApps(); renderTiles(); } catch(e){ toast(e.error||'Delete failed','err'); }
+                const nameInput = wrap.querySelector(`input[data-k="name"][data-key="${id}"]`);
+                const appName = nameInput?.value?.trim() || '';
+                Modal.open({
+                  title: 'Delete App',
+                  bodyHTML: 'Are you sure you want to delete "<span id="delAppName"></span>"?',
+                  confirmText: 'Delete',
+                  onOpen: ()=>{ $('#delAppName').textContent = appName; },
+                  onConfirm: async ()=>{
+                    try {
+                      await api('/api/apps/'+encodeURIComponent(id), { method:'DELETE' });
+                      toast('App deleted');
+                      await loadApps();
+                      renderTiles();
+                    } catch(e){
+                      toast(e.error||'Delete failed','err');
+                    }
+                  }
+                });
               };
             });
           };
@@ -636,14 +654,48 @@
         }
 
         // SAB settings
-        try{ const sabCfg=await api('/api/sab'); $('#sabBaseUrl').value=sabCfg.sab.baseUrl||''; $('#sabApiKey').value=sabCfg.sab.apiKey||''; $('#saveSab').onclick=async ()=>{ await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) }); toast('SAB settings saved'); }; }catch{}
+        try{
+          const sabCfg=await api('/api/sab');
+          $('#sabBaseUrl').value=sabCfg.sab.baseUrl||'';
+          $('#sabApiKey').value=sabCfg.sab.apiKey||'';
+          const saveSabBtn=$('#saveSab');
+          if(saveSabBtn){
+            saveSabBtn.onclick=async ()=>{
+              await api('/api/sab',{ method:'PUT', body: JSON.stringify({ baseUrl: $('#sabBaseUrl').value.trim(), apiKey: $('#sabApiKey').value.trim() }) });
+              toast('SAB settings saved');
+              $('#testSab')?.click();
+            };
+          }
+          const testSabBtn=$('#testSab');
+          if(testSabBtn){
+            testSabBtn.onclick=async ()=>{
+              try{ const r=await api('/api/sab/test'); if(r.ok) toast('SAB connection successful'); else toast(`SAB test failed (status ${r.status})`,'err'); }
+              catch(e){ toast(e.error||'SAB test failed','err'); }
+            };
+          }
+        }catch{}
 
         // Plex settings
         try{
           const plexCfg = await api('/api/plex');
           if (plexCfg && plexCfg.plex){ const tokInput=$('#plexToken'); const urlInput=$('#plexBaseUrl'); if(tokInput) tokInput.value = plexCfg.plex.token || ''; if(urlInput) urlInput.value = plexCfg.plex.baseUrl || ''; }
-          const savePlexBtn=$('#savePlex'); if (savePlexBtn){ savePlexBtn.onclick = async ()=>{ const token=($('#plexToken')?.value||'').trim(); let baseUrl=($('#plexBaseUrl')?.value||'').trim(); await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) }); toast('Plex settings saved'); if($('#testPlex')) $('#testPlex').click(); }; }
-          const testBtn=$('#testPlex'); if (testBtn){ testBtn.onclick = async ()=>{ const wrap=$('#plexTestResult'); if(wrap){ wrap.classList.remove('hidden'); wrap.textContent='Testing…'; } try{ const result=await api('/api/plex/test'); if(wrap) wrap.textContent=JSON.stringify(result,null,2); }catch(e){ if(wrap) wrap.textContent='Error: '+(e?.message||e); } }; }
+          const savePlexBtn=$('#savePlex');
+          if (savePlexBtn){
+            savePlexBtn.onclick = async ()=>{
+              const token=($('#plexToken')?.value||'').trim();
+              let baseUrl=($('#plexBaseUrl')?.value||'').trim();
+              await api('/api/plex', { method:'PUT', body: JSON.stringify({ baseUrl, token }) });
+              toast('Plex settings saved');
+              $('#testPlex')?.click();
+            };
+          }
+          const testBtn=$('#testPlex');
+          if (testBtn){
+            testBtn.onclick = async ()=>{
+              try{ const result=await api('/api/plex/test'); if(result.ok) toast('Plex connection successful'); else toast(`Plex test failed (status ${result.status})`,'err'); }
+              catch(e){ toast(e.error||'Plex test failed','err'); }
+            };
+          }
         }catch{}
 
         await renderUsers();
@@ -780,7 +832,7 @@
     function startNowPlayingPolling(){ clearInterval(S.npTimer); if(!shouldShowNowPlaying()){ $('#nowPlayingWrap').classList.add('hidden'); return; } fetchNowPlaying(); S.npTimer=setInterval(fetchNowPlaying, 5000); }
 
     function hasMfaEnabled(){ return !!(S.me && S.me.totpSecret); }
-    async function setupMfaUI(){ const box=$('#mfaBox'); if(!box) return; const enabled=hasMfaEnabled(); $('#mfaStatus').textContent = enabled ? 'Enabled' : 'Disabled'; $('#mfaStart').classList.toggle('hidden', enabled); $('#mfaDisable').classList.toggle('hidden', !enabled); $('#mfaSetup').classList.add('hidden'); $('#mfaStart').onclick = async ()=>{ try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'start' }) }); if(r.otpauth){ $('#mfaSetup').classList.remove('hidden'); $('#mfaOtpauth').textContent=r.otpauth; try{ const u=new URL(r.otpauth); $('#mfaSecret').textContent=new URLSearchParams(u.search).get('secret')||''; }catch{} renderQRTo('#mfaQr', r.otpauth); $('#mfaCopyLink').onclick=()=>copyToClipboard(r.otpauth); $('#mfaCopySecret').onclick=()=>{ try{ const u=new URL(r.otpauth); copyToClipboard(new URLSearchParams(u.search).get('secret')||''); }catch{} }; } }catch(e){ toast(e.error||'Failed to start setup','err'); } };
+    async function setupMfaUI(){ const box=$('#mfaBox'); if(!box) return; const enabled=hasMfaEnabled(); $('#mfaStatus').textContent = enabled ? 'Enabled' : 'Disabled'; $('#mfaStart').classList.toggle('hidden', enabled); $('#mfaDisable').classList.toggle('hidden', !enabled); $('#mfaSetup').classList.add('hidden'); $('#mfaStart').onclick = async ()=>{ try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'start' }) }); if(r.otpauth && r.secret){ $('#mfaSetup').classList.remove('hidden'); $('#mfaOtpauth').textContent=r.otpauth; $('#mfaSecret').textContent=r.secret; $('#mfaCopyLink').onclick=()=>copyToClipboard(r.otpauth); $('#mfaCopySecret').onclick=()=>copyToClipboard(r.secret); } }catch(e){ toast(e.error||'Failed to start setup','err'); } }; $('#mfaDisable').onclick = async ()=>{ if(!confirm('Disable authenticator app for this account?')) return; try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'disable' }) }); S.me=r.user; toast('MFA disabled'); setupMfaUI(); }catch(e){ toast(e.error||'Failed to disable','err'); } }; $('#mfaVerify').onclick = async ()=>{ const code=$('#mfaCode').value.trim(); if(!/^[0-9]{6}$/.test(code)){ toast('Enter the 6‑digit code from your app','err'); return; } try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'verify', code }) }); S.me=r.user; toast('MFA enabled and saved'); setupMfaUI(); }catch(e){ toast(e.error||'Verification failed','err'); } }; }
       $('#mfaDisable').onclick = async ()=>{ if(!confirm('Disable authenticator app for this account?')) return; try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'disable' }) }); S.me=r.user; toast('MFA disabled'); setupMfaUI(); }catch(e){ toast(e.error||'Failed to disable','err'); } };
       $('#mfaVerify').onclick = async ()=>{ const code=$('#mfaCode').value.trim(); if(!/^[0-9]{6}$/.test(code)){ toast('Enter the 6‑digit code from your app','err'); return; } try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify({ mfaAction:'verify', code }) }); S.me=r.user; toast('MFA enabled and saved'); setupMfaUI(); }catch(e){ toast(e.error||'Verification failed','err'); } };
     }
@@ -795,6 +847,7 @@
       try{ const r=await api('/api/me',{ method:'PUT', body: JSON.stringify(body) }); S.me=r.user; toast('Saved.'); const displayName=[S.me.firstName,S.me.lastName].filter(Boolean).join(' ')||S.me.username; $('#userName').textContent = displayName; const ua=$('#userAvatar'), ui=$('#userInitial'); if(S.me.profileImage){ ua.src=S.me.profileImage; ua.classList.remove('hidden'); ui.classList.add('hidden'); } else { ui.textContent = initialsFor(S.me); ui.classList.remove('hidden'); ua.classList.add('hidden'); } }
       catch(err){ toast(err.error||'Save failed','err'); }
     });
+    $('#btn-admin-close').onclick = ()=> show('#view-apps');
     $('#btn-settings-close').onclick = ()=> show('#view-apps');
 
     // SAB controls


### PR DESCRIPTION
## Summary
- Hook up the "Close Admin" button so it returns to the apps view
- Provide an initial `data.json` so user changes like app order persist
- Ignore node modules and other build artifacts with a `.gitignore`
- Add SABnzbd and Plex connection test buttons that report results via toast notifications
- Show one-time passcode setup details after registration using a text-based secret instead of a QR code

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b373e449b88328b832191ceee58a58