### PR TITLE
Prevent demoting the last remaining admin

### DIFF
--- a/app.mjs
+++ b/app.mjs
@@ -142,7 +142,13 @@ app.patch('/api/users/:username', authMiddleware, adminOnly, (req,res)=>{
   const j = load();
   const u = (j.users||[]).find(x=>x.username===req.params.username);
   if(!u) return res.status(404).json({ error:'Not found' });
-  if (role && (role==='admin' || role==='user')) u.role = role;
+  if (role && (role==='admin' || role==='user')) {
+    if (role === 'user' && u.role === 'admin') {
+      const adminCount = (j.users||[]).filter(x=>x.role==='admin').length;
+      if (adminCount <= 1) return res.status(400).json({ error:'At least one admin required' });
+    }
+    u.role = role;
+  }
   save(j);
   res.json({ ok:true });
 });

--- a/public/index.html
+++ b/public/index.html
@@ -728,6 +728,7 @@
       const ul = $('#usersList'); if (!ul) return;
       const [usersRes, rcRes] = await Promise.all([ api('/api/users'), api('/api/reset-codes') ]);
       const rcByUser = groupResetCodesByUser(rcRes.resetCodes);
+      const adminCount = usersRes.users.filter(u=>u.role==='admin').length;
 
       ul.innerHTML='';
       for(const u of usersRes.users){
@@ -777,7 +778,10 @@
             </div>
           </div>`;
 
-        row.querySelector('[data-act="promote"]').onclick = async ()=>{ const newRole = u.role==='admin'?'user':'admin'; try{ await api(`/api/users/${u.username}`, { method:'PATCH', body: JSON.stringify({ role:newRole })}); toast('Role updated'); await renderUsers(); }catch(e){ toast(e.error||'Update failed','err'); } };
+        const promoteBtn = row.querySelector('[data-act="promote"]');
+        promoteBtn.disabled = adminCount <= 1 && u.role === 'admin';
+        promoteBtn.classList.toggle('opacity-50', promoteBtn.disabled);
+        promoteBtn.onclick = async ()=>{ const newRole = u.role==='admin'?'user':'admin'; try{ await api(`/api/users/${u.username}`, { method:'PATCH', body: JSON.stringify({ role:newRole })}); toast('Role updated'); await renderUsers(); }catch(e){ toast(e.error||'Update failed','err'); } };
         row.querySelector('[data-act="genreset"]').onclick = ()=> openResetModal(u.username);
         row.querySelector('[data-act="delete"]').onclick = async ()=>{ if(!confirm(`Delete user ${u.username}? This cannot be undone.`)) return; try{ await api(`/api/users/${encodeURIComponent(u.username)}`, { method:'DELETE' }); toast('User deleted'); await renderUsers(); }catch(e){ toast(e.error||'Delete failed','err'); } };
         row.querySelectorAll('.del-code').forEach(b=> b.onclick = async ()=>{ if(!confirm('Delete this reset code?')) return; await api(`/api/reset-codes/${b.dataset.code}`, { method:'DELETE' }); toast('Reset code deleted'); await renderUsers(); });


### PR DESCRIPTION
## Summary
- Prevent server from demoting last admin by rejecting role change when only one admin exists
- Disable "Toggle Admin" button in user list when only one admin remains

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --check app.mjs`
- `npm start`