### PR TITLE
Handle missing QR library during MFA setup

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -530,11 +530,11 @@
           e.target.classList.add('hidden');
           const wrap=$('#registerMfa');
           wrap.classList.remove('hidden');
-          renderQRTo('#qr', otpauth);
-          $('#otpauth').textContent=otpauth;
-          $('#otpsecret').textContent=sec;
-          $('#copyOtpauth').onclick=()=>copyToClipboard(otpauth);
-          $('#copySecret').onclick=()=>copyToClipboard(sec);
+          $('#otpauth').textContent = otpauth;
+          $('#otpsecret').textContent = sec;
+          $('#copyOtpauth').onclick = ()=>copyToClipboard(otpauth);
+          $('#copySecret').onclick = ()=>copyToClipboard(sec);
+          try{ renderQRTo('#qr', otpauth); }catch(err){ console.error(err); }
           const otpInput=$('#registerOtp');
           $('#registerVerify').onclick=async ()=>{
             const code=(otpInput.value||'').trim();
@@ -899,11 +899,11 @@
           if(r.otpauth){
             const sec = r.secret || (()=>{ try{ const u=new URL(r.otpauth); return new URLSearchParams(u.search).get('secret')||''; }catch{} return ''; })();
             $('#mfaSetup').classList.remove('hidden');
-            renderQRTo('#mfaQr', r.otpauth);
-            $('#mfaOtpauth').textContent=r.otpauth;
-            $('#mfaSecret').textContent=sec;
-            $('#mfaCopyLink').onclick=()=>copyToClipboard(r.otpauth);
-            $('#mfaCopySecret').onclick=()=>copyToClipboard(sec);
+            $('#mfaOtpauth').textContent = r.otpauth;
+            $('#mfaSecret').textContent = sec;
+            $('#mfaCopyLink').onclick = ()=>copyToClipboard(r.otpauth);
+            $('#mfaCopySecret').onclick = ()=>copyToClipboard(sec);
+            try{ renderQRTo('#mfaQr', r.otpauth); }catch(err){ console.error(err); }
             S.me = r.user || S.me;
           }
         }catch(e){ toast(e.error||'Failed to start setup','err'); }


### PR DESCRIPTION
## Summary
- Populate MFA otpauth link and secret before attempting to render QR code
- Guard QR rendering so registration/setup still works when QR library is missing

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b49b16ac58832884783616914eabae