### PR TITLE
Normalize SMTP host for Gmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ SMTP_FROM=dashboard@example.com
 APP_URL=http://192.168.1.182:8088
 ```
 
+For Gmail, use your app-specific password and set:
+
+```
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=465
+SMTP_SECURE=true
+SMTP_USER=you@gmail.com
+SMTP_PASS=your-app-password
+SMTP_FROM=you@gmail.com
+```
+
+The app will automatically strip any protocol (`smtp://`, `http://`), embedded port, or path from `SMTP_HOST`, default to TLS when using port 465, and enforce STARTTLS on port 587.
+
 Every user must register with a unique email address. Password recovery links are sent to that email, so configure SMTP before inviting users.
 
 ## GitHub setup

--- a/app.mjs
+++ b/app.mjs
@@ -42,10 +42,21 @@ function initMailer(){
   const j = load();
   const cfg = j.smtp || SMTP_ENV;
   if (cfg.host){
+    let host = String(cfg.host).trim();
+    host = host.replace(/^(?:https?|smtps?):\/\//i, '').split(/[/?#]/)[0];
+    if(host.includes(':')){
+      const [h,p] = host.split(':');
+      host = h;
+      if(!cfg.port) cfg.port = Number(p);
+    }
+    const port = Number(cfg.port) || 587;
+    const secure = cfg.secure !== undefined ? !!cfg.secure : (port === 465);
+    const requireTLS = !secure && port === 587 ? true : undefined;
     mailer = nodemailer.createTransport({
-      host: cfg.host,
-      port: Number(cfg.port) || 587,
-      secure: !!cfg.secure,
+      host,
+      port,
+      secure,
+      requireTLS,
       auth: cfg.user ? { user: cfg.user, pass: cfg.pass } : undefined
     });
   } else {


### PR DESCRIPTION
## Summary
- Strip protocols, ports, and paths from SMTP host before creating Nodemailer transport
- Default to TLS on port 465 and force STARTTLS on port 587

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b4c34557c883289ba9bac867a29d7e