### PR TITLE
feat: add PWA support

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="/manifest.json" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <link rel="apple-touch-icon" href="/icon.svg" />
   <title>Zaharia Media — Dashboard</title>
 
   <!-- Favicon -->
@@ -373,5 +378,12 @@
 
   <!-- QR lib -->
   <script type="module" src="/main.js"></script>
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("/service-worker.js").catch(e => console.error("SW registration failed", e));
+      });
+    }
+  </script>
 </body>
 </html>

--- a/frontend/public/icon.svg
+++ b/frontend/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#000"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="256" fill="#fff">ZM</text>
+</svg>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Zaharia Media Dashboard",
+  "short_name": "ZMedia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/frontend/public/service-worker.js
+++ b/frontend/public/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'zm-cache-v1';
+const URLS_TO_CACHE = ['/', '/index.html', '/manifest.json', '/icon.svg'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/public/icon.svg
+++ b/public/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <rect width="512" height="512" fill="#000"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="256" fill="#fff">ZM</text>
+</svg>

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="manifest" href="/manifest.json" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <link rel="apple-touch-icon" href="/icon.svg" />
   <title>Zaharia Media — Dashboard</title>
 
   <!-- Favicon -->
@@ -374,5 +379,12 @@
   </div>
 
   <!-- QR lib -->
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", () => {
+        navigator.serviceWorker.register("/service-worker.js").catch(e => console.error("SW registration failed", e));
+      });
+    }
+  </script>
 </body>
 </html>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Zaharia Media Dashboard",
+  "short_name": "ZMedia",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    {
+      "src": "/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'zm-cache-v1';
+const URLS_TO_CACHE = ['/', '/index.html', '/manifest.json', '/icon.svg'];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys => Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k))))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});


### PR DESCRIPTION
## Summary
- enable iOS web app installation with manifest and icons
- register service worker for offline caching
- replace PNG icons with an SVG to avoid binary files

## Testing
- `npm run build` (fails: vite: not found)
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68b4d9e9346c8328ad10fde891201825